### PR TITLE
Add 'test' directory to TypeScript include paths

### DIFF
--- a/scripts/newPlugin.ts
+++ b/scripts/newPlugin.ts
@@ -131,7 +131,10 @@ async function main() {
           outDir: "dist",
           skipLibCheck: true,
         },
-        include: ["src"],
+        include: [
+          "src",
+          "test",
+        ],
       },
       null,
       2,


### PR DESCRIPTION
In order for VS Code to pick up `tsconfig.json`, I believe `tests` needs to be listed here? I couldn't seem to get VS Code to pick up `tsconfig.json` any other way.